### PR TITLE
Update grid-template-columns utility to use percentage widths

### DIFF
--- a/src/components/Table/ResponsiveTable.css
+++ b/src/components/Table/ResponsiveTable.css
@@ -8,19 +8,27 @@
 
   
 @media screen and (min-width: 768px) {
-.responsive-table .row {
+.responsive-table .row,
+.responsive-table .table-row
+ {
   display: grid;
   grid-template-columns: var(--grid-template-columns);
   gap: 1rem;
-  padding: 0.5rem 1rem;
-  align-items: space-between ;
+  align-items: center;;
   border-bottom: 1px solid #333;
   width:100%;
 }
+ .responsive-table .table-header {
+    font-weight: bold;
+    background-color: #f4f4f4;
+    border-bottom: 2px solid black;
+  }
 
 .responsive-table .cell {
   /* Normal cell styling */
-  padding: 0.25rem 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-right: 1px solid #ccc;
 }
 
 /* Hide cell label on desktop */

--- a/src/components/Table/TableHeader.tsx
+++ b/src/components/Table/TableHeader.tsx
@@ -1,5 +1,6 @@
 import type { AppColumnDef } from "../../types/app-column-def";
 import { TableCell } from "./TableCell";
+import { getGridTemplateColumns } from "../../utilities/get-grid-template-columns";
 
 export interface TableHeaderProps<TData> {
   columns: AppColumnDef<TData>[];
@@ -7,9 +8,18 @@ export interface TableHeaderProps<TData> {
 
 export function TableHeader<TData>({ columns }: TableHeaderProps<TData>) {
   return (
-    <div className="table-row table-header">
+    <div
+      className="table-row table-header"
+      style={
+        {
+          "--grid-template-columns": getGridTemplateColumns(columns),
+        } as React.CSSProperties
+      }
+    >
       {columns.map((col) => (
-        <TableCell key={col.id} header={col.header} />
+        <TableCell key={col.id} header={col.header}>
+          {col.header}
+        </TableCell>
       ))}
     </div>
   );

--- a/src/utilities/get-grid-template-columns.ts
+++ b/src/utilities/get-grid-template-columns.ts
@@ -3,5 +3,11 @@ import type { AppColumnDef } from "../types/app-column-def";
 export function getGridTemplateColumns<TData>(
   columns: AppColumnDef<TData>[]
 ): string {
-  return columns.map((col) => `${col.size}px`).join(" ");
+  const totalWidth = columns.reduce((sum, col) => sum + col.size, 0);
+  return columns
+    .map((col) => {
+      const percent = (col.size / totalWidth) * 100;
+      return `${percent.toFixed(2)}%`;
+    })
+    .join(" ");
 }


### PR DESCRIPTION
Updated  the grid-template-columns utility to use percentage-based widths instead of fixed pixels.  Previously, the entire page was scrollable. However, it's currently behaving as a fixed layout, and I'm working on the issue 